### PR TITLE
Force-reinstall pydantic<2.0.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN pip install --no-cache-dir --upgrade -r /code/demo/requirements.txt
 # resolve issue with tf==2.4 and gradio dependency collision issue
 RUN pip install --force-reinstall typing_extensions==4.7.1
 
+# lower pydantic version to work with typing_extensions deprecation
+RUN pip install --force-reinstall "pydantic<2.0.0"
+
 # Install wget
 RUN apt install wget -y && \
     apt install unzip


### PR DESCRIPTION
Fixes issue #25.

Same fix was used successfully with the `neukit` repo (see [here](09b5fd04681749c113d58600a276a4036e27b940)).