### PR TITLE
Remove pedantic and typing_extension installation instruction hacks in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,6 @@ WORKDIR /code
 COPY ./demo/requirements.txt /code/demo/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /code/demo/requirements.txt
 
-# resolve issue with tf==2.4 and gradio dependency collision issue
-RUN pip install --force-reinstall typing_extensions==4.7.1
-
-# lower pydantic version to work with typing_extensions deprecation
-RUN pip install --force-reinstall "pydantic<2.0.0"
-
 # Install wget
 RUN apt install wget -y && \
     apt install unzip

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ To access the live demo, click on the `Hugging Face` badge above. Below is a sna
 Alternatively, you can deploy the software locally. Note that this is only relevant for development purposes. Simply dockerize the app and run it:
 
 ```
-docker build -t AeroPath .
-docker run -it -p 7860:7860 AeroPath
+docker build -t aeropath .
+docker run -it -p 7860:7860 aeropath
 ```
 
 Then open `http://127.0.0.1:7860` in your favourite internet browser to view the demo.


### PR DESCRIPTION
Fixes #60.